### PR TITLE
fix int division in python template player

### DIFF
--- a/players/python/proboj.py
+++ b/players/python/proboj.py
@@ -172,7 +172,7 @@ class Harbor:
         if not self.visible:
             return base_price[resource.value]
         return int(
-            min(100 / (self.storage[resource] + 3) + 1, 4) * base_price[resource.value]
+            min(100 // (self.storage[resource] + 3) + 1, 4) * base_price[resource.value]
         )
 
     def __str__(self):


### PR DESCRIPTION
- v go aj v C sa robi int division, ale v python `/` robi float division
- cize napr. ak v harbore bolo `100` stone - tak server vypocita price `2` ale python `3` - a tympadom si hrac mysli ze si moze dovolit kupit menej resources